### PR TITLE
Add `bare` option to be able to deploy a function without framework

### DIFF
--- a/rise-cli/test/ping_functions_test.js
+++ b/rise-cli/test/ping_functions_test.js
@@ -23,10 +23,12 @@ describe('pingFunctions', function() {
 
     session = {
       stackName: 'foo-stack',
-      compressedFunctions:[
-        { functionName: 'AppIndex' },
-        { functionName: 'AppCreate' }
-      ],
+      functions: {
+        AppIndex: null,
+        AppCreate: {
+          memory: 128
+        }
+      },
       aws: {
         lambda: {
           listFunctions: listFunctionsFn,
@@ -52,5 +54,25 @@ describe('pingFunctions', function() {
           Payload: JSON.stringify({riseTest: 1})
         });
       });
+  });
+
+  context('when bare is true', function() {
+    beforeEach(function() {
+      session.functions.AppIndex = { bare: true };
+    });
+
+    it('does not ping', function() {
+      return pingFunctions(session)
+      .then(function(session) {
+        expect(session).to.not.be.null;
+        expect(listFunctionsFn).to.have.been.calledOnce;
+        expect(listFunctionsFn).to.have.been.calledWith({});
+        expect(invokeFn).to.have.been.calledOnce;
+        expect(invokeFn).to.have.been.calledWith({
+          FunctionName: 'foo-stack-AppCreate-789012',
+          Payload: JSON.stringify({riseTest: 1})
+        });
+      });
+    });
   });
 });

--- a/rise-cli/test_proj/functions/callbacks/index.js
+++ b/rise-cli/test_proj/functions/callbacks/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+exports.handle = (event, context, callback) => {
+  callback(null, 'Hello from Lambda!');
+};

--- a/rise-cli/test_proj/rise.yaml
+++ b/rise-cli/test_proj/rise.yaml
@@ -24,3 +24,5 @@ functions:
   deleteTask:
   updateTask:
   home:
+  callbacks:
+    bare: true


### PR DESCRIPTION
This is to add an option not to use web framework wrapper, so custom trigger does not have to use framework.

i.e.
```yaml
functions:
   createTasks:
     bare: true
```